### PR TITLE
fix typo, add multiprocess args

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The dataset used for the experiments are
 ### Training the model
 To train the model on the Voxceleb2 dataset, you can run
 
-- python main.py --net resnet34s --batch_size 160 --gpu 2,3 --lr 0.001 --warmup_raito 0.1 --optimizer adam --epochs 128 --multiprocess 8 --loss softmax --data_path ../path_to_voxceleb2
+- python main.py --net resnet34s --batch_size 160 --gpu 2,3 --lr 0.001 --warmup_ratio 0.1 --optimizer adam --epochs 128 --multiprocess 8 --loss softmax --data_path ../path_to_voxceleb2
 
 ### Model 
 - Models will be updated 

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ parser.add_argument('--gpu', default='', type=str)
 parser.add_argument('--resume', default='', type=str)
 parser.add_argument('--batch_size', default=64, type=int)
 parser.add_argument('--data_path', default='/scratch/local/ssd/weidi/voxceleb2/dev/wav', type=str)
+parser.add_argument('--multiprocess', default=12, type=int)
 # set up network configuration.
 parser.add_argument('--net', default='resnet34s', choices=['resnet34s', 'resnet34l'], type=str)
 parser.add_argument('--ghost_cluster', default=2, type=int)
@@ -51,7 +52,7 @@ def main():
 
     # construct the data generator.
     params = {'dim': (257, 250, 1),
-              'mp_pooler': toolkits.set_mp(processes=12),
+              'mp_pooler': toolkits.set_mp(processes=args.multiprocess),
               'nfft': 512,
               'spec_len': 250,
               'win_length': 400,


### PR DESCRIPTION
- Fixed typo of the example training command
- Added missing argument for `multiprocess` for `toolkits.set_mp`