### PR TITLE
feat: remove problem specific code and commented out code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repo contains a Keras implementation of the paper,
 - [Python 2.7.15](https://www.continuum.io/downloads)
 - [Keras 2.2.4](https://keras.io/)
 - [Tensorflow 1.8.0](https://www.tensorflow.org/)
+- CUDA 9 
+- See requirements.txt
+
+There seems to be a bug in this version of librosa such that loading wav files is cripplingly slow (1 second per short file), you can replace read_wav with read_wav_fast in utils.py to fix this, but be aware that the result is that the sample rate is not constant. 
 
 ### Data
 The dataset used for the experiments are
@@ -47,7 +51,9 @@ for example, the model trained with ResNet34s trained by adam with softmax, and 
 ### Fine Tuning the model
 The weights provided do not include the weights of the final prediction layer, so one needs to randomly initialise this with `network.load_weights(os.path.join(args.resume), by_name=True, skip_mismatch=True)` in main.py
 
-python main.py --net resnet34s --gpu 0  --ghost_cluster 2 --vlad_cluster 8 --batch_size 16 --lr 0.001 --warmup_ratio 0.1 --optimizer adam --epochs 128 --multiprocess 8 --loss softmax --data_path /media/ben/datadrive/Zalo/voice-verification/Train-Test-Data/dataset/ --resume=/media/ben/datadrive/Software/VGG-Speaker-Recognition/model/weights_dropbox.h5
+python main.py --net resnet34s --gpu 0  --ghost_cluster 2 --vlad_cluster 8 --batch_size 16 --lr 0.001 --warmup_ratio 0.1 --optimizer adam --epochs 128 --multiprocess 8 --loss softmax --resume=../model/gvlad_softmax/resnet34_vlad8_ghost2_bdim512_deploy/weights.h5 
+
+Note that `--data_path /path_to_your_dataset/dataset/` can be used to point to your own dataset, but you will need to write a small function in toolkits.py to return the corresponding datalist file contents.
 
 
 ### Licence

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# conda install cudatoolkit==9.0 then linked to an environment with export LD_LIBRARY_PATH=/home/ben/anaconda3/envs/entrance/lib:$LD_LIBRARY_PATH missing libcudnn.so.7
 keras==2.2.4
 tensorflow-gpu==1.8.0
 librosa==0.3.1
 scikit-learn==0.16.1
+# As this requires CUDA 9, one can install with `conda install cudatoolkit==9.0` and if it complains it is missing a library (e.g. libcudnn.so.7) then you link it by export LD_LIBRARY_PATH=/home/ben/anaconda3/envs/entrance/lib:$LD_LIBRARY_PATH missing libcudnn.so.7

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,8 @@ import sys
 import keras
 import numpy as np
 
+np.seterr(all='raise')
+
 sys.path.append('../tool')
 import toolkits
 
@@ -35,8 +37,7 @@ parser.add_argument('--ohem_level', default=0, type=int,
                     help='pick hard samples from (ohem_level * batch_size) proposals, must be > 1')
 global args
 args = parser.parse_args()
-import numpy as np
-np.seterr(all='raise')
+
 def main():
 
     # gpu configuration
@@ -76,8 +77,6 @@ def main():
                                            mode='train', args=args)
     # ==> load pre-trained model ???
     mgpu = len(keras.backend.tensorflow_backend._get_available_gpus())
-    #import pdb
-    #pdb.set_trace()
 
     if args.resume:
         print("Attempting to load", args.resume)

--- a/src/main.py
+++ b/src/main.py
@@ -48,8 +48,8 @@ def main():
     # ==================================
     #       Get Train/Val.
     # ==================================
-    trnlist, trnlb = toolkits.get_zalo_datalist(args, path='/media/ben/datadrive/Zalo/voice-verification/vgg_db_files/train.txt')
-    vallist, vallb = toolkits.get_zalo_datalist(args, path='/media/ben/datadrive/Zalo/voice-verification/vgg_db_files/val.txt')
+    trnlist, trnlb = toolkits.get_voxceleb2_datalist(args, path='../meta/voxlb2_train.txt')
+    vallist, vallb = toolkits.get_voxceleb2_datalist(args, path='../meta/voxlb2_val.txt')
 
     # construct the data generator.
     params = {'dim': (257, 250, 1),
@@ -79,7 +79,6 @@ def main():
     #import pdb
     #pdb.set_trace()
 
-    print("mpu", mgpu)
     if args.resume:
         print("Attempting to load", args.resume)
         if args.resume:
@@ -89,7 +88,6 @@ def main():
                     # https://github.com/WeidiXie/VGG-Speaker-Recognition/issues/46
                     network.load_weights(os.path.join(args.resume), by_name=True, skip_mismatch=True)
                 else:
-                    print("loading N+1", mgpu)
                     network.layers[mgpu + 1].load_weights(os.path.join(args.resume))
                 print('==> successfully loading model {}.'.format(args.resume))
             else:
@@ -142,8 +140,8 @@ def main():
                               epochs=args.epochs,
                               max_queue_size=10,
                               callbacks=callbacks,
-                              use_multiprocessing=False, # False
-                              workers=1, # 1
+                              use_multiprocessing=False,
+                              workers=1,
                               verbose=1)
 
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -44,7 +44,7 @@ def main():
     print('==> calculating test({}) data lists...'.format(args.test_type))
 
     if args.test_type == 'normal':
-        verify_list = np.loadtxt('/media/ben/datadrive/Zalo/voice-verification/vgg_db_files/val_trials.txt', str)
+        verify_list = np.loadtxt('../meta/voxceleb1_veri_test.txt', str)
     elif args.test_type == 'hard':
         verify_list = np.loadtxt('../meta/voxceleb1_veri_test_hard.txt', str)
     elif args.test_type == 'extend':
@@ -133,7 +133,6 @@ def main():
 def set_result_path(args):
     model_path = args.resume
     exp_path = model_path.split(os.sep)
-    print("Paths are", '../result', exp_path[2], exp_path[3])
     result_path = os.path.join('../result', exp_path[2], exp_path[3])
     if not os.path.exists(result_path): os.makedirs(result_path)
     return result_path

--- a/src/train.sh
+++ b/src/train.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-export LD_LIBRARY_PATH=/home/ben/anaconda3/envs/entrance/lib:$LD_LIBRARY_PATH
-
-python main.py --net resnet34s --gpu 0  --ghost_cluster 2 --vlad_cluster 8 --batch_size 16 --lr 0.001 --warmup_ratio 0.1 --optimizer adam --epochs 128 --multiprocess 8 --loss softmax --data_path /media/ben/datadrive/Zalo/voice-verification/Train-Test-Data/dataset/ --resume=/media/ben/datadrive/Software/VGG-Speaker-Recognition/model/weights_dropbox.h5

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,24 +9,24 @@ from scipy import interpolate
 # ===============================================
 #       code from Arsha for loading data.
 # ===============================================
-def load_wav(vid_path, sr, mode='train'):
-
-    #t1=timelib.time()
-    #print("start loading wav")
-    #print(sr)
-    #wav, sr_ret = librosa.load(vid_path, sr=sr)
-    #sr_ret, wav = scipy.io.wavfile.read(vid_path)
-
+def load_wav_fast(vid_path, sr, mode='train'):
+    """load_wav() is really slow on this version of librosa.
+    load_wav_fast() is faster but we are not ensuring a consistent sampling rate"""
     wav, sr_ret = sf.read(vid_path)
-    #sr_ret, old_audio = scipy.io.wavfile.read(vid_path)
-    #if sr_ret != sr:
-    #    new_rate = sr
-    #    number_of_samples = round(len(old_audio) * float(new_rate) / sr_ret)
-    #    wav = sps.resample(old_audio, number_of_samples)
 
+    if mode == 'train':
+        extended_wav = np.append(wav, wav)
+        if np.random.random() < 0.3:
+            extended_wav = extended_wav[::-1]
+        return extended_wav
+    else:
+        extended_wav = np.append(wav, wav[::-1])
+        return extended_wav
 
-    #assert sr_ret == 16000, "we need same samplerate as librosa originally provided but is: " +str(sr_ret)
-    #print("finish loading wav", timelib.time()-t1)
+def load_wav(vid_path, sr, mode='train'):
+    wav, sr_ret = librosa.load(vid_path, sr=sr)
+    assert sr_ret == sr
+
     if mode == 'train':
         extended_wav = np.append(wav, wav)
         if np.random.random() < 0.3:
@@ -43,8 +43,6 @@ def lin_spectogram_from_wav(wav, hop_length, win_length, n_fft=1024):
 
 
 def load_data(path, win_length=400, sr=16000, hop_length=160, n_fft=512, spec_len=250, mode='train'):
-    #print("starting loading a datum")
-    #t1 = timelib.time()
     wav = load_wav(path, sr=sr, mode=mode)
     linear_spect = lin_spectogram_from_wav(wav, hop_length, win_length, n_fft)
     mag, _ = librosa.magphase(linear_spect)  # magnitude
@@ -61,7 +59,6 @@ def load_data(path, win_length=400, sr=16000, hop_length=160, n_fft=512, spec_le
     # preprocessing, subtract mean, divided by time-wise var
     mu = np.mean(spec_mag, 0, keepdims=True)
     std = np.std(spec_mag, 0, keepdims=True)
-    #print("finished loading a datum", timelib.time() - t1)
     return (spec_mag - mu) / (std + 1e-5)
 
 

--- a/tool/toolkits.py
+++ b/tool/toolkits.py
@@ -102,17 +102,6 @@ def get_voxceleb2_datalist(args, path):
         f.close()
     return audiolist, labellist
 
-def get_zalo_datalist(args, path):
-    with open(path) as f:
-        strings = f.readlines()
-        audiolist = np.array([os.path.join(args.data_path, string.split()[0]) for string in strings])
-        labellist = np.array([int(string.split()[1]) for string in strings])
-        f.close()
-    print("Getting audio, e.g.", audiolist[0:5])
-    print("Getting labels, e.g.", labellist[0:5])
-    return audiolist, labellist
-
-
 def calculate_eer(y, y_score):
     # y denotes groundtruth scores,
     # y_score denotes the prediction scores.


### PR DESCRIPTION
Just a little cleanup from the last PR, to remove some code specific to my use-case

Note that although I had to replace
```
    wav, sr_ret = librosa.load(vid_path, sr=sr)
    assert sr_ret == sr
```
with 
```
    wav, sr_ret = sf.read(vid_path)
```
To fix a librosa issue of it taking 1 second to load each clip, but it may be a  problematic fix as the result is variable sample rate per clip. As such this PR restores the original `load_wav` as the default, but adds a note to the readme explaining this option. 